### PR TITLE
Update to account for all filters in the WFPC2 Instrument Handbook.

### DIFF
--- a/wavelength_ranges.py
+++ b/wavelength_ranges.py
@@ -110,7 +110,7 @@ NIR_MIN = 647
 
 # This regular expression matches the number inside a filter name, e.g.,
 # 'F606W'. This is generally the center wavelength of the bandpass in nm.
-FILTER_REGEX = re.compile("[FG](|[QR])(\d+)([WMNHLX]|LP)")
+FILTER_REGEX = re.compile("[FG](|[QR])(\d+)([WMNHLX]|LP|AW|BW|BN15)")
 
 # This is a list of filter/grating names whose ranges would not be correctly
 # inferred from the name based on the usual algorithm. This is needed for two
@@ -119,33 +119,38 @@ FILTER_REGEX = re.compile("[FG](|[QR])(\d+)([WMNHLX]|LP)")
 #   - the filter is wide enough to encompass a range that is outside the one
 #     expected based on the center wavelength alone.
 
+# Instrument names in comments after each line indicate that MST has verified
+# the entry from that instrument's handbook in Spring 2022. 
+
 FILTER_EXCEPTIONS = {
     "CLEAR": ["UV", "VIS", "NIR"],
-    "F130LP": ["UV", "VIS"],
-    "F130LP": ["UV", "VIS", "NIR"],
+    "F130LP": ["UV", "VIS", "NIR"],    # WFPC2
     "F165LP": ["UV", "VIS", "NIR"],
     "F200LP": ["UV", "VIS", "NIR"],
     "F305LP": ["UV", "VIS"],
     "F350LP": ["UV", "VIS", "NIR"],
     "F370LP": ["UV", "VIS"],
     "F372M": ["UV", "VIS"],
-    "F380W": ["UV", "VIS"],
-    "F410M": ["UV", "VIS"],
+    "F380W": ["UV", "VIS"],            # WFPC2
+    "F410M": ["UV", "VIS"],            # WFPC2
     "F430W": ["UV", "VIS"],
     "F435W": ["UV", "VIS"],
     "F600LP": ["VIS", "NIR"],
-    "F606W": ["VIS", "NIR"],
-    "F606W": ["VIS", "NIR"],
-    "F606W": ["VIS", "NIR"],
-    "F622W": ["VIS", "NIR"],
+    "F606W": ["VIS", "NIR"],           # WFPC2
     "F622W": ["VIS", "NIR"],
     "F625W": ["VIS", "NIR"],
-    "F675W": ["VIS", "NIR"],
-    "F675W": ["VIS", "NIR"],
-    "F702W": ["VIS", "NIR"],
+    "F675W": ["VIS", "NIR"],           # WFPC2
+    "F702W": ["VIS", "NIR"],           # WFPC2
     "F718M": ["VIS", "NIR"],
-    "FQCH4N": ["VIS", "NIR"],
+    "FQCH4N": ["VIS", "NIR"],          # WFPC2
+    "FQCH4N15": ["VIS", "NIR"],        # WFPC2
+    "FQCH4N33": ["VIS", "NIR"],        # WFPC2
+    "FQCH4P15": ["VIS", "NIR"],        # WFPC2
     "FQUVN": ["UV", "VIS"],
+    "FR418N": ["VIS"],                 # WFPC2
+    "FR533N": ["VIS"],                 # WFPC2
+    "FR680N": ["VIS", "NIR"],          # WFPC2
+    "FR868N": ["NIR"],                 # WFPC2
     "FR459M": ["UV", "VIS"],
     "G430L": ["UV", "VIS"],
     "G430M": ["UV", "VIS"],
@@ -200,6 +205,9 @@ def ranges_from_one_filter(filter_name):
     if value >= NIR_MIN:
         results.append("NIR")
 
+    if not results:
+        raise ValueError("Wavelength range not found: " + filter_name)
+        
     return results
 
 


### PR DESCRIPTION
I added a few options to FILTER_REGEX to account for filters such as F160BW and F160BN15, which should be straightforwardly categorized according to their central wavelength.  
I removed duplicates from FILTER_EXCEPTIONS.  
I added "#WFPC2" in comments to entries in FILTER_EXCEPTIONS that I have verified in the WFPC2 Instrument Handbook.  Eventually I'd like to see every entry in FILTER_EXCEPTIONS have such a comment, so that we can track where the rules come from.  
I added entries for methane filters (starting with "FQ") and ramp filters (starting with "FR") to FILTER_EXCEPTIONS.