### PR TITLE
Test run on program ids of different instruments

### DIFF
--- a/HST/citations/__init__.py
+++ b/HST/citations/__init__.py
@@ -198,8 +198,6 @@ class Citation_Information:
             info = citation_information_from_apt(filename)
         elif filename_lc.endswith('.pro'):
             info = citation_information_from_pro(filename)
-        elif filename_lc.endswith('.txt'):
-            info = citation_information_from_text(filename)
         else:
             raise ValueError('unrecognized file format: ' + filename)
 

--- a/HST/citations/__init__.py
+++ b/HST/citations/__init__.py
@@ -66,6 +66,7 @@ YEARS_FOR_CYCLE = {  # YEARS_FOR_CYCLE[cycle_number] = (start_year, end_year)
     27: (2019, 2020),
     28: (2020, 2021),
     29: (2021, 2022),
+    30: (2022, 2023),
 }
 
 # Servicing Missions:

--- a/HST/hst_helper/general_utils.py
+++ b/HST/hst_helper/general_utils.py
@@ -11,7 +11,7 @@ import os
 import pdslogger
 
 from . import (CITATION_INFO_DICT,
-               DOCUMENT_EXT,
+               DOCUMENT_EXT_FOR_CITATION_INFO,
                INST_ID_DICT,
                INST_PARAMS_DICT,
                PRIMARY_RES_DICT,
@@ -131,7 +131,7 @@ def get_citation_info(proposal_id, logger):
     for file in os.listdir(pipeline_dir):
         _, _, ext = file.rpartition('.')
         # We don't have an implementation to create citation info from pdf.
-        if (ext in DOCUMENT_EXT and ext != 'pdf') or file == PROGRAM_INFO_FILE:
+        if ext in DOCUMENT_EXT_FOR_CITATION_INFO:
             file_path = f'{pipeline_dir}/{file}'
             if formatted_proposal_id not in CITATION_INFO_DICT:
                 CITATION_INFO_DICT[formatted_proposal_id] = (

--- a/HST/pipeline/pipeline_query_hst_moving_targets.py
+++ b/HST/pipeline/pipeline_query_hst_moving_targets.py
@@ -116,7 +116,7 @@ if taskqueue:
             logger.info(f'Queue query_hst_products for {proposal_id}')
             queue_next_task(proposal_id, '', 1, logger)
         else:
-            logger.info(f'{pipeline_dir} exists')
+            logger.info(f'{pipeline_dir} already exists. Pipeline stops.')
 
     # TODO: TASK QUEUE
     # - re-queue query-hst-moving-targets with a 30-day delay

--- a/HST/pipeline/pipeline_retrieve_hst_visit.py
+++ b/HST/pipeline/pipeline_retrieve_hst_visit.py
@@ -75,10 +75,11 @@ logger.open('retrieve-hst-visit ' + ' '.join(sys.argv[1:]), limits=LIMITS)
 
 try:
     retrieve_hst_visit(proposal_id, visit, logger)
-except:
+except Exception as e:
     # Before raising the error, remove the task queue of the proposal id from database.
     formatted_proposal_id = get_formatted_proposal_id(proposal_id)
     remove_all_task_queue_for_a_prog_id(formatted_proposal_id)
+    logger.error(e)
     raise
 
 logger.close()

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -613,7 +613,10 @@ def label_hst_fits_filepaths(filepaths, root='', *,
 
             # Maybe this is supposed to happen
             spt_hdulist = pyfits.open(ipppssoot_dict['spt_fullpath'])
-            scidata = spt_hdulist[0].header['SCIDATA']
+            try:
+                scidata = spt_hdulist[0].header['SCIDATA']
+            except KeyError:
+                scidata = None
             spt_hdulist.close()
 
             if scidata:

--- a/HST/product_labels/date_support.py
+++ b/HST/product_labels/date_support.py
@@ -26,6 +26,7 @@
 #   Set the file's modification date.
 ##########################################################################################
 
+import astropy
 import datetime
 import os
 import re
@@ -131,7 +132,10 @@ def get_header_date(hdulist):
         raise ValueError(f'unsupported IRAF-TLM format: "{value}"')
 
     # Most files have DATE "yyyy-mm-dd" or "dd/mm/yy"
-    value = header0.get('DATE', '')
+    try:
+        value = header0.get('DATE', '')
+    except astropy.io.fits.verify.VerifyError:
+        value = ''
     match = YYYY_MM_DD_PATTERN.fullmatch(value)
     if match:
         dates_found.append(value)

--- a/HST/product_labels/date_support.py
+++ b/HST/product_labels/date_support.py
@@ -118,11 +118,15 @@ def get_header_date(hdulist):
         raise ValueError(f'unsupported FITSDATE format: "{value}"')
 
     # Some files have IRAF-TLM "hh:mm:ss (dd/mm/yyyy)
+    # For cases like 5217, some files have IRAF-TLM value "2010-02-17T16:49:27", so we
+    # also check the YYYY_MM_DD_HH_MM_SS_PATTERN here.
     value = header0.get('IRAF-TLM', '')
     match = IRAF_TLM_PATTERN.fullmatch(value)
     if match:
         (hh_mm_ss, dd, mm, yyyy) = match.groups()
         dates_found.append(f'{yyyy}-{mm}-{dd}T{hh_mm_ss}')
+    elif match := YYYY_MM_DD_HH_MM_SS_PATTERN.fullmatch(value):
+        dates_found.append(value)
     elif value:
         raise ValueError(f'unsupported IRAF-TLM format: "{value}"')
 

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -998,7 +998,6 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ############################################################
     # Return the dictionary
     ############################################################
-    print('FINAL RETURN DICT------------------')
     return hst_dictionary
 
 ##########################################################################################

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -545,7 +545,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
                 # second; join with a plus.
                 filters = [filter1, filter2]
                 filters.sort()
-                return '+'.join(filters)
+                filter_name = '+'.join(filters)
 
         elif instrument_id == 'FGS':
             filter_name = header0['CAST_FLT']
@@ -998,7 +998,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ############################################################
     # Return the dictionary
     ############################################################
-
+    print('FINAL RETURN DICT------------------')
     return hst_dictionary
 
 ##########################################################################################

--- a/HST/templates/TARGET_LABEL.xml
+++ b/HST/templates/TARGET_LABEL.xml
@@ -21,19 +21,21 @@
         $END_FOR
         </Alias_List>
     $END_IF
-    <Modification_History>
-        <Modification_Detail>
-            <modification_date>$label_date$</modification_date>
-            <version_id>1.0</version_id>
-            <description>Initial PDS4 version</description>
-        </Modification_Detail>
-    </Modification_History>
+        <Modification_History>
+            <Modification_Detail>
+                <modification_date>$label_date$</modification_date>
+                <version_id>1.0</version_id>
+                <description>Initial PDS4 version</description>
+            </Modification_Detail>
+        </Modification_History>
     </Identification_Area>
     <Target>
         <name>$target['name']$</name>
         <type>$target['type']$</type>
-        <description>
-            $WRAP(12, 90, target['description'].strip())$
-        </description>
+        $IF(len(target['description']))
+            <description>
+                $WRAP(12, 90, target['description'].strip())$
+            </description>
+        $END_IF
     </Target>
 </Product_Context>

--- a/get_lists_of_test_proposal_ids.py
+++ b/get_lists_of_test_proposal_ids.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     filter_dict = {}
     for inst in target_inst:
         obs = Observations.query_criteria(
-            dataproduct_type=["image"],
+            # dataproduct_type=["image"],
             dataRights="PUBLIC",
             obs_collection=["HST"],
             instrument_name=inst,


### PR DESCRIPTION
- This is the pull request to track issues (mainly at the stage of creating data labels) and update the code after test runs on program ids of different instruments.
- Issues created: #65 #66 #67 #70
- Some other issues caused by missing info from downloaded fits like ones (see below for details)  in 16214, 10427, 14609 

- Summary of ids being run and issues:

================================
python pipeline/pipeline_run.py --prog-id 17099 14903 13197 11536 13874
COS/NUV: 
ok: 11536, 17099 
issue: 14903 13197 13874
- 14903, 13197, 13874 #65

================================
python pipeline/pipeline_run.py --prog-id 15490 16704 7240 9112 12478
STIS/CCD: 
issue: 15490 16704 7240 9112 12478
- 7240, 9112 #66
- 15490, 16704, 12478 #65

================================
python pipeline/pipeline_run.py --prog-id 13736 15379 7315 10341 8218
STIS/NUV-MAMA: 
ok: 13736, 7315, 10341, 8218 
issue: 15379
- 15379 #65

================================
python pipeline/pipeline_run.py --prog-id 6621 11497 5624 9320 10786
WFPC2/PC: 
ok: 6621, 11497, 5624, 9320  
issue: 10786
- 10786 #67 

================================
python pipeline/pipeline_run.py --prog-id 6215 5217 9256 11187 6648
WFPC2/WFC: 
ok: 6215, 5217, 9256, 11187, 6648

================================
python pipeline/pipeline_run.py --prog-id 13805 8659 7309 16917 14930
STIS/FUV-MAMA: 
ok: 13805, 8659, 7309, 16917, 14930

================================
python pipeline/pipeline_run.py --prog-id 5167 6736 5829 6679 5844
HRS/1: 
ok: 5167, 6736, 5829, 6679, 5844

================================
python pipeline/pipeline_run.py --prog-id 10774 9678 9985 10770 10801
ACS/HRC: 
ok: 10774, 9678, 9985, 10801 
issue: 10770
- 10770 #70

================================
python pipeline/pipeline_run.py --prog-id 14036 14609 16770 12607 12312
COS/FUV: 
ok: 14036 
issue: 14609, 16770, 12312, 12607
- 14609 ERROR | COS/FUV table does not have a column "SEGMENT": ld8x03jqq/ld8x03jqq_rawacq.fits
- 16770, 12607, 12312 #65 

================================
python pipeline/pipeline_run.py --prog-id 6025 6029 5837 5642
HRS/2: 
ok: 6025, 5642 
issue: 6029, 5837
- 6029, 5837 #67

================================
python pipeline/pipeline_run.py --prog-id 5824 6315 6591 6663 5662
FOS/RD: 
ok: 5824, 6315, 6591, 6663, 5662

================================
python pipeline/pipeline_run.py --prog-id 6328 5493
FOS/BL: 
ok: 6328 
issue: 5493
- 5493 #67

================================
python pipeline/pipeline_run.py --prog-id 9355 7885 7823 7319 10161
NICMOS/NIC1: 
ok: 7885, 7823, 7319 
issue: 9335, 10161
- 9335, 10161 #67

================================
python pipeline/pipeline_run.py --prog-id 7181 7239 7822
NICMOS/NIC3: 
ok: 7181, 7239, 7822 

================================
python pipeline/pipeline_run.py --prog-id 7240 7176 7241 7182 7244 
NICMOS/NIC2: 
ok: 7176, 7241, 7182, 7244 
issue: 7240
- 7240 #66

================================
python pipeline/pipeline_run.py --prog-id 13936 13632 9296 10156 13012 
ACS/SBC: ok: 13936, 13632, 9296, 10156, 13012 

================================
python pipeline/pipeline_run.py --prog-id 10095 16418 16214 10427 13474
ACS/WFC: 
ok: 10095, 16418, 13474 
issue: 16214, 10427
- 16214 ERROR | WARNING: Ignored comet identifier: P/2017 K2: je9ua1voq/je9ua1voq_spt.fits
        ERROR | WARNING: Ignored comet identifier: 2: je9ua1voq/je9ua1voq_spt.fits
        ERROR | No comet found: ['P/2017 K2', '2']: je9ua1voq/je9ua1voq_spt.fits
        ERROR | WARNING: Ignored comet identifier: P/2017 K2: je9ua1vpq/je9ua1vpq_spt.fits
        ERROR | WARNING: Ignored comet identifier: 2: je9ua1vpq/je9ua1vpq_spt.fits
        ERROR | No comet found: ['P/2017 K2', '2']: je9ua1vpq/je9ua1vpq_spt.fits
        DEBUG | Reference file found for je9ua1vqq: je9ua1vqq/je9ua1vqq_raw.fits
        ERROR | WARNING: Ignored comet identifier: P/2017 K2: je9ua1vqq/je9ua1vqq_spt.fits
        ERROR | WARNING: Ignored comet identifier: 2: je9ua1vqq/je9ua1vqq_spt.fits
        ERROR | No comet found: ['P/2017 K2', '2']: je9ua1vqq/je9ua1vqq_spt.fits
        DEBUG | Reference file found for je9ua1vrq: je9ua1vrq/je9ua1vrq_raw.fits
        ERROR | WARNING: Ignored comet identifier: P/2017 K2: je9ua1vrq/je9ua1vrq_spt.fits
        ERROR | WARNING: Ignored comet identifier: 2: je9ua1vrq/je9ua1vrq_spt.fits
        ERROR | No comet found: ['P/2017 K2', '2']: je9ua1vrq/je9ua1vrq_spt.fits
        DEBUG | Reference file found for je9ua1vtq: je9ua1vtq/je9ua1vtq_raw.fits
        ERROR | WARNING: Ignored comet identifier: P/2017 K2: je9ua1vtq/je9ua1vtq_spt.fits
        ERROR | WARNING: Ignored comet identifier: 2: je9ua1vtq/je9ua1vtq_spt.fits
        ERROR | No comet found: ['P/2017 K2', '2']: je9ua1vtq/je9ua1vtq_spt.fits
- 10427 #66 and these:
ERROR | Missing FITS keyword APERTURE: j96o02010/j96o02011_spt.fits
        FATAL | **** KeyError 'FILTER1': j96o02010/j96o02011_spt.fits
        File "/Users/yu-jenchang/Desktop/seti/workspace/pds-hst-pipeline/HST/product_labels/hst_dictionary_support.py", line 533, in fill_hst_dictionary
            filter1 = header0['FILTER1']
        ERROR | Missing FITS keyword OBSMODE: j96o02010/j96o02011_spt.fits
        ERROR | Undetermined wavelength range for UNK: j96o02010/j96o02011_spt.fits
        ERROR | Missing FITS keyword APERTURE: j96o02010/j96o02012_spt.fits
        FATAL | **** KeyError 'FILTER1': j96o02010/j96o02012_spt.fits
        File "/Users/yu-jenchang/Desktop/seti/workspace/pds-hst-pipeline/HST/product_labels/hst_dictionary_support.py", line 533, in fill_hst_dictionary
            filter1 = header0['FILTER1']
        ERROR | Missing FITS keyword OBSMODE: j96o02010/j96o02012_spt.fits
        ERROR | Undetermined wavelength range for UNK: j96o02010/j96o02012_spt.fits
        ERROR | Missing FITS keyword OBSMODE: j96o01010/j96o01011_spt.fits
        ERROR | Undetermined wavelength range for UNK: j96o01010/j96o01011_spt.fits
        DEBUG | Target ['134340 Pluto']: j96o01010/j96o01011_spt.fits
        WARNING | No science data for j96o01012
        ERROR | Missing FITS keyword APERTURE: j96o01010/j96o01012_spt.fits
        FATAL | **** KeyError 'FILTER1': j96o01010/j96o01012_spt.fits
  File "/Users/yu-jenchang/Desktop/seti/workspace/pds-hst-pipeline/HST/product_labels/hst_dictionary_support.py", line 533, in fill_hst_dictionary
    filter1 = header0['FILTER1']
        ERROR | Missing FITS keyword OBSMODE: j96o01010/j96o01012_spt.fits

================================
python pipeline/pipeline_run.py --prog-id 6846 5392
FOC/96: 
ok: 6846, 5392  

================================
python pipeline/pipeline_run.py --prog-id 6025 5167 
HRS: 
ok: 6025, 5167

================================
python pipeline/pipeline_run.py --prog-id 16712 16463 16310 14042 15248
WFC3/UVIS: 
ok: 16712, 16463, 16310, 14042, 15248

================================
python pipeline/pipeline_run.py --prog-id 15406 15581 12237 14138 13664
WFC3/IR:  
ok: 15406, 15581, 13664, 12237, 14138
