### PR TITLE
NaN replacement disabled; template modified to identify NaN as the not-applicable constant

### DIFF
--- a/HST/hst_helper/general_utils.py
+++ b/HST/hst_helper/general_utils.py
@@ -85,10 +85,10 @@ def create_xml_label(template_path, label_path, data_dict, logger):
 
     logger.info('Insert data to the label template')
     TEMPLATE.write(data_dict, label_path)
-    if TEMPLATE.ERROR_COUNT == 1:
+    if TEMPLATE.error_count == 1:
         logger.error('1 error encountered', label_path)
-    elif TEMPLATE.ERROR_COUNT > 1:
-        logger.error(f'{TEMPLATE.ERROR_COUNT} errors encountered', label_path)
+    elif TEMPLATE.error_count > 1:
+        logger.error(f'{TEMPLATE.error_count} errors encountered', label_path)
 
 def create_csv(csv_path, data, logger):
     """Create csv with given csv file path and data to be written into the csv file.

--- a/HST/hst_helper/query_utils.py
+++ b/HST/hst_helper/query_utils.py
@@ -255,10 +255,12 @@ def download_files(table, dir, logger=None, testing=False):
     os.makedirs(dir, exist_ok=True)
 
     if len(table) > 0:
-        logger.info(f'Download files to {dir}')
+        logger.info(f'Downloading files to {dir}')
         if not testing: # pragma: no cover, no need to download files during the test
             try:
                 Observations.download_products(table, download_dir=dir)
+                logger.info(f'Downloading files to {dir} has completed!')
             except Exception as e: # errors when downloading files
+                logger.critical(f'Error happened during downloading files to {dir}')
                 logger.exception(e)
                 raise

--- a/HST/pipeline/pipeline_label_hst_products.py
+++ b/HST/pipeline/pipeline_label_hst_products.py
@@ -5,7 +5,7 @@
 # Syntax:
 # pipeline_label_hst_products.py [-h] [--proposal-id PROPOSAL_ID] [--visit VISIT]
 #                                [--path PATH] [--old OLD][--select SELECT] [--date DATE]
-#                                [--replace-nans] [--reset-dates] [--log LOG] [--quiet]
+#                                [--reset-dates] [--log LOG] [--quiet]
 #
 # Enter the --help option to see more information.
 #
@@ -14,8 +14,6 @@
 # - Compare the staged FITS files to those in an existing bundle, if any.
 # - Create a new XML label for each file.
 # - Reset the modification dates of the FITS files to match their production date at MAST.
-# - If any file contains NaNs, rename the original file with “-original” appended,
-#   and then rewrite the file without NaNs.
 ##########################################################################################
 
 import argparse
@@ -62,9 +60,6 @@ parser.add_argument('--select', type=str, action='store', default='',
 parser.add_argument('--date', type=str, action='store', default='',
     help="""Optional retrieval date from MAST in yyyy-mm-dd format. This is used if the
          product creation date cannot be otherwise inferred from the file.""")
-
-parser.add_argument('--replace-nans', '-N', action='store_true',
-    help='Replace any floating-point NaNs with a special constant.')
 
 parser.add_argument('--reset-dates', '-D', action='store_true',
     help='Reset file modification dates to match the inferred product creation times.')
@@ -127,8 +122,7 @@ try:
                                old_directories = [args.old],
                                retrieval_date = args.date,
                                logger = logger,
-                               reset_dates = args.reset_dates,
-                               replace_nans = args.replace_nans)
+                               reset_dates = args.reset_dates)
 except:
     # Before raising the error, remove the task queue of the proposal id from database.
     remove_all_tasks_for_a_prog_id(formatted_proposal_id)

--- a/HST/pipeline/pipeline_label_hst_products.py
+++ b/HST/pipeline/pipeline_label_hst_products.py
@@ -94,7 +94,7 @@ if proposal_id and visit and not target_path:
     target_path = (HST_DIR['staging'] + '/hst_' + proposal_id.zfill(5) + '/visit_'
                    + visit.zfill(2))
 
-logger = pdslogger.PdsLogger('pds.hst.label-hst-products')
+logger = pdslogger.PdsLogger('pds.hst.label-hst-products-' + proposal_id)
 if not args.quiet:
     logger.add_handler(pdslogger.stdout_handler)
 

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -814,10 +814,10 @@ def label_hst_fits_filepaths(filepaths, root='', *,
 
         # Override the time coordinates for EPC files
         if basename.endswith('_epc.fits'):
-            ipppssoot_dict['time_coordinates'] = get_bintable_time_coordinates(
+            basename_dict['time_coordinates'] = get_bintable_time_coordinates(
                                                             basename_dict['fullpath'],
                                                             logger)
-            ipppssoot_dict['time_is_actual'] = True
+            basename_dict['time_is_actual'] = True
 
         suffix = basename_dict['suffix']
         instrument_id = basename_dict['instrument_id']

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -454,7 +454,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
             if ipppssoot in associations_by_ipppssoot:
                 associates = associations_by_ipppssoot[ipppssoot]
                 if reference_ipppssoot in associations_by_ipppssoot:
-                    associations_by_ipppssoot[reference_ipppssoot].append(associates)
+                    associations_by_ipppssoot[reference_ipppssoot] += associates
                 else:
                     associations_by_ipppssoot[reference_ipppssoot] = associates
                 del associations_by_ipppssoot[ipppssoot]
@@ -536,7 +536,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
 
     # Insert the associations list from the ASN file
     for ipppssoot, associations in associations_by_ipppssoot.items():
-        ippsoot_dict = info_by_ipppssoot[ipppssoot]
+        ipppssoot_dict = info_by_ipppssoot[ipppssoot]
 
         validated_associates = []
         missing_associates = []
@@ -559,8 +559,8 @@ def label_hst_fits_filepaths(filepaths, root='', *,
                 missing_associates.append((associate, memtype))
                 logger.warn('Missing associate for ' + ipppssoot, associate)
 
-        ippsoot_dict['associates'] = validated_associates
-        ippsoot_dict['missing_associates'] = missing_associates
+        ipppssoot_dict['associates'] = validated_associates
+        ipppssoot_dict['missing_associates'] = missing_associates
 
     # Fill in the merged suffixes
     for ipppssoot, ipppssoot_dict in info_by_ipppssoot.items():
@@ -598,7 +598,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
     for ipppssoot, ipppssoot_dict in info_by_ipppssoot.items():
         if 'spt_suffix' in ipppssoot_dict:
             continue
-        for (associate, _) in ippsoot_dict['associates']:
+        for (associate, _) in ipppssoot_dict['associates']:
             if 'spt_suffix' in info_by_ipppssoot[associate]:
                 ipppssoot_dict['spt_suffix'] = info_by_ipppssoot[associate]['spt_suffix']
                 ipppssoot_dict['spt_fullpath'] = \
@@ -762,11 +762,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
 
         # Target identifications
         spt_fullpath = ipppssoot_dict['spt_fullpath']
-        if reference_suffix:
-            xml_content = reference_dict['previous_xml']
-        else:
-            xml_content = ''
-
+        xml_content = reference_dict['previous_xml']
         if xml_content:                 # use the old identification if available
             target_ids = get_target_identifications(xml_content)
         else:
@@ -1164,8 +1160,7 @@ def fill_modification_date(basename_dict, info_by_ipppssoot, logger):
     if latest_date in ipppssoot_dict['timetags']:
         latest_date = ipppssoot_dict['timetags'][latest_date]
     elif 'T' not in latest_date:
-        logger.debug(f'No time tags for {latest_date}', basename_dict['fullpath'])
-        print(ipppssoot_dict['timetags'].keys())
+        logger.debug(f'No hh:mm:ss for {latest_date}', basename_dict['fullpath'])
 
     basename_dict['modification_date'] = latest_date
     if latest_date == '0000':

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -51,8 +51,7 @@ def label_hst_fits_directories(directories, root='', *,
                                old_root = '',
                                retrieval_date = '',
                                logger = None,
-                               reset_dates = True,
-                               replace_nans = False):
+                               reset_dates = True):
     """Process one or more directories of HST FITS files, returning the information needed
     for all of their PDS4 labels as a dictionary keyed by the basenames.
 
@@ -69,8 +68,9 @@ def label_hst_fits_directories(directories, root='', *,
         logger              pdslogger to use; None for default EasyLogger.
         reset_dates         True to reset the modification date of each file to the date
                             found in the FITS header.
-        replace_nans        True to rewrite each file without NaNs if NaNs are found.
     """
+
+    replace_nans = False    # disabled feature
 
     filepaths = get_filepaths(directories, root, match_pattern)
 

--- a/HST/product_labels/get_time_coordinates.py
+++ b/HST/product_labels/get_time_coordinates.py
@@ -4,6 +4,9 @@
 import julian
 import pdslogger
 
+from astropy.io import fits as pyfits
+
+
 def get_time_coordinates(ref_hdulist, spt_hdulist, filepath='', logger=None):
     """Return the tuple (start_time, stop_time, is_actual).
 
@@ -27,7 +30,6 @@ def get_time_coordinates(ref_hdulist, spt_hdulist, filepath='', logger=None):
                 pass
 
         return alt
-
 
     logger = logger or pdslogger.NullLogger()
 
@@ -149,5 +151,24 @@ def get_time_coordinates(ref_hdulist, spt_hdulist, filepath='', logger=None):
     stop_date_time = julian.ymdhms_format_from_day_sec(day, sec, suffix='Z')
 
     return (start_date_time, stop_date_time, True)
+
+
+def get_bintable_time_coordinates(filepath, logger):
+    """Get the tuple (start_time, stop_time) from MJD values embedded in a binary FITS
+    table.
+    """
+
+    hdulist = pyfits.open(filepath)
+    mjds = hdulist[1].data['TIME']
+    hdulist.close()
+
+    times = []
+    for mjd in (mjds.min(), mjds.max()):
+        day, sec = julian.day_sec_from_mjd(mjd)
+        iso = julian.format_day_sec(day, sec)
+        times.append(iso)
+
+    logger.debug('Times retrieved from bintable', filepath)
+    return times
 
 ##########################################################################################

--- a/HST/product_labels/get_time_coordinates.py
+++ b/HST/product_labels/get_time_coordinates.py
@@ -165,7 +165,7 @@ def get_bintable_time_coordinates(filepath, logger):
     times = []
     for mjd in (mjds.min(), mjds.max()):
         day, sec = julian.day_sec_from_mjd(mjd)
-        iso = julian.format_day_sec(day, sec)
+        iso = julian.format_day_sec(day, sec, suffix='Z')
         times.append(iso)
 
     logger.debug('Times retrieved from bintable', filepath)

--- a/HST/product_labels/hdu_data_descriptions.py
+++ b/HST/product_labels/hdu_data_descriptions.py
@@ -163,29 +163,31 @@ DATA_CLASS_TO_NOUN = {
     'UNKNOWN'          : ('UNKNOWN DATA CLASS', 'UNKNOWN DATA CLASSES'),
 }
 
-def fill_hdu_data_descriptions(ipppssoot, ipppssoot_dict, suffix, log_text, logger):
+def fill_hdu_data_descriptions(ipppssoot, suffix, info_by_ipppssoot, log_text, logger):
     """Fill in the description fields for all of the data objects in one file based on its
     suffix.
 
     Input:
-        ipppssoot       the file's IPPPSSOOT.
-        ipppssoot_dict  the dictionary describing every file having the same IPPPSSOOT.
-        suffix          the long suffix for one file.
-        log_text        True to write all description strings to the log.
-        logger          pdslogger to use; None to suppress logging.
+        ipppssoot           the file's IPPPSSOOT.
+        suffix              the long suffix for one file.
+        info_by_ipppssoot   the dictionary describing all IPPPSSOOTs.
+        log_text            True to write all description strings to the log.
+        logger              pdslogger to use; None to suppress logging.
 
-    Return:             the set of all descriptions generated. Useful to review the text
-                        being generated to confirm that it is correct.
+    Return:                 the set of all descriptions generated. Useful to review the
+                            text being generated to confirm that it is correct.
     """
 
     logger = logger or pdslogger.NullLogger()
+
+    ipppssoot_dict = info_by_ipppssoot[ipppssoot]
+    suffix_dict    = ipppssoot_dict[suffix]
 
     hst_dictionary  = ipppssoot_dict['hst_dictionary']
     instrument_id   = hst_dictionary['instrument_id']
     channel_id      = hst_dictionary['channel_id']
     hst_proposal_id = hst_dictionary['hst_proposal_id']
 
-    suffix_dict = ipppssoot_dict[suffix]
     filepath  = suffix_dict['fullpath']
     hdu_dicts = suffix_dict['hdu_dictionaries']
 
@@ -269,9 +271,8 @@ def fill_hdu_data_descriptions(ipppssoot, ipppssoot_dict, suffix, log_text, logg
             associated_sci_class = sci_class
         else:
             (associated_ipppssoot, associated_suffix) = selected_pairs[0]
-            associated_suffix_dict = (ipppssoot_dict['by_ipppssoot']
-                                                    [associated_ipppssoot]
-                                                    [associated_suffix])
+            associated_suffix_dict = (info_by_ipppssoot[associated_ipppssoot]
+                                                       [associated_suffix])
             associated_hdu_dicts = associated_suffix_dict['hdu_dictionaries']
             for k, hdu_dict in enumerate(associated_hdu_dicts):
                 extver = hdu_dict['extver']

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -807,7 +807,8 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     try:
         mtflag = merged['MTFLAG']
     except KeyError:
-        logger.error('Missing FITS keyword MTFLAG', filepath)
+        logger.warn('Missing FITS keyword MTFLAG', filepath)
+        mtflag = False
 
     if mtflag in ('T', '1', True):
         moving_target_flag = True

--- a/HST/product_labels/nan_support.py
+++ b/HST/product_labels/nan_support.py
@@ -19,6 +19,28 @@ import numpy as np
 import os
 import astropy.io.fits as pyfits
 
+def get_nan_hdus(hdulist):
+    """The list of HDU indices in which the data array contains NaNs."""
+
+    # Check HDUs one by one...
+    nan_hdus = []
+    for k, hdu in enumerate(hdulist):
+
+        # If the data object isn't an array, continue
+        if not isinstance(hdu.data, np.ndarray):
+            continue
+
+        # Only floating-point arrays can have NaNs
+        if hdu.data.dtype.kind != 'f':
+            continue
+
+        # Check for NaNs; save info if found
+        mask = np.isnan(hdu.data)
+        if np.any(mask):
+            nan_hdus.append(k)
+
+    return nan_hdus
+
 def _get_nan_info(hdulist):
     """Return info about any of the data arrays in this FITS file that contain NaNs.
     If the returned list is empty, this file contains no NaNs.

--- a/HST/query_hst_products.py
+++ b/HST/query_hst_products.py
@@ -95,6 +95,7 @@ def query_hst_products(proposal_id, logger=None):
     trl_products = get_trl_products(table)
 
     try:
+        logger.info(f'Download trl products to {trl_dir}')
         download_files(trl_products, trl_dir, logger)
     except: #pragma: no cover
         # Downloading failed, removed all the trl files to restore a clean directory.

--- a/HST/retrieve_hst_visit.py
+++ b/HST/retrieve_hst_visit.py
@@ -46,6 +46,7 @@ def retrieve_hst_visit(proposal_id, visit, logger=None, testing=False):
 
     try:
         # Download all accepted files
+        logger.info(f'Download accepted products to {files_dir}')
         download_files(filtered_products, files_dir, logger, testing)
     except: #pragma: no cover
         # Downloading failed, removed the visit folder under the staging directory, and
@@ -61,7 +62,7 @@ def retrieve_hst_visit(proposal_id, visit, logger=None, testing=False):
         # database.
         formatted_proposal_id = get_formatted_proposal_id(proposal_id)
         remove_all_tasks_for_a_prog_id(formatted_proposal_id)
-        logger.exception('MAST trl files downlaod failure')
+        logger.exception(f'MAST trl files downlaod failure for {proposal_id}')
         raise
 
     return len(filtered_products)

--- a/HST/templates/PRODUCT_LABEL.xml
+++ b/HST/templates/PRODUCT_LABEL.xml
@@ -104,13 +104,6 @@ $IF(hst_dictionary["mast_pipeline_version_id"])
 $ELSE
       or around $modification_date[:10]$.
 $END_IF
-$IF(has_nans)
-
-      Note: This file has been modified from the original source. The source file contains
-      NaN ("not-a-number") values inside some data arrays, but NaN values are not allowed
-      in PDS4 data products. In this file, all NaN values have been replaced by a fixed
-      constant, as specified below in the Special_Constants class.
-$END_IF
 $IF(not ipppssoot_dict['reference_suffix'])
 
       Note that observation "$ipppssoot$" did not obtain science data. Only ancillary data
@@ -387,7 +380,7 @@ $FOR(hdu_dict,k=hdu_dictionaries)
     $END_FOR
     $IF(k in hdus_with_nans)
       <Special_Constants>
-        <invalid_constant>$nan_replacement$</invalid_constant>
+        <not_applicable_constant>NaN</not_applicable_constant>
       </Special_Constants>
     $END_IF
    $ELSE_IF(ddict["data_class"] == "Table_Binary")

--- a/HST/templates/PRODUCT_LABEL.xml
+++ b/HST/templates/PRODUCT_LABEL.xml
@@ -180,7 +180,9 @@ $FOR(target=target_identifications)
       </description>
   $END_IF
       <Internal_Reference>
-        <lid_reference>$target[4]$</lid_reference>
+        <lid_reference>
+          $target[4]$
+        </lid_reference>
         <reference_type>data_to_target</reference_type>
       </Internal_Reference>
     </Target_Identification>

--- a/HST/templates/PRODUCT_LABEL.xml
+++ b/HST/templates/PRODUCT_LABEL.xml
@@ -23,9 +23,10 @@ $ONCE(FILE_AREA = "File_Area_Ancillary" if processing_level == "Ancillary" else 
 $ONCE(prop_id=hst_dictionary["hst_proposal_id"])
 $ONCE(formatted_prop_id=str(prop_id).zfill(5))
 $ONCE(inst_id=hst_dictionary["instrument_id"])
-$ONCE(ipppssoot=hst_dictionary["mast_observation_id"])
   <Identification_Area>
-    <logical_identifier>urn:nasa:pds:hst_$prop_id$:$collection_name$:$ipppssoot$$lid_suffix$</logical_identifier>
+    <logical_identifier>
+      $product_lid$
+    </logical_identifier>
     <version_id>$version_id[0]$.$version_id[1]$</version_id>
     <title>
       $WRAP(6, 90, basename + ": " + product_title)$
@@ -104,7 +105,7 @@ $IF(hst_dictionary["mast_pipeline_version_id"])
 $ELSE
       or around $modification_date[:10]$.
 $END_IF
-$IF(not ipppssoot_dict['reference_suffix'])
+$IF(not ipppssoot_dict['reference_suffixes'])
 
       Note that observation "$ipppssoot$" did not obtain science data. Only ancillary data
       files documenting this activity are available.
@@ -134,7 +135,9 @@ $END_FOR
       <name>HST observing program $prop_id$</name>
       <type>Individual Investigation</type>
       <Internal_Reference>
-        <lid_reference>urn:nasa:pds:context:investigation:individual.hst_$formatted_prop_id$</lid_reference>
+        <lid_reference>
+          urn:nasa:pds:context:investigation:individual.hst_$formatted_prop_id$
+        </lid_reference>
         <reference_type>data_to_investigation</reference_type>
       </Internal_Reference>
     </Investigation_Area>
@@ -144,7 +147,9 @@ $END_FOR
         <name>Hubble Space Telescope</name>
         <type>Host</type>
         <Internal_Reference>
-          <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.hst</lid_reference>
+          <lid_reference>
+            urn:nasa:pds:context:instrument_host:spacecraft.hst
+          </lid_reference>
           <reference_type>is_instrument_host</reference_type>
         </Internal_Reference>
       </Observing_System_Component>
@@ -152,7 +157,9 @@ $END_FOR
         <name>$instrument_name$</name>
         <type>Instrument</type>
         <Internal_Reference>
-          <lid_reference>urn:nasa:pds:context:instrument:hst.$inst_id.lower()$</lid_reference>
+          <lid_reference>
+            urn:nasa:pds:context:instrument:hst.$inst_id.lower()$
+          </lid_reference>
           <reference_type>is_instrument</reference_type>
         </Internal_Reference>
       </Observing_System_Component>
@@ -300,7 +307,9 @@ $IF(processing_level != "Ancillary")
   $FOR(info=browse_info)
 
     <Internal_Reference>
-      <lidvid_reference>urn:nasa:pds:hst_$prop_id$:$info.collection_name$:$ipppssoot$$info.lid_suffix$::$version_id[0]$.0</lidvid_reference>
+      <lidvid_reference>
+        urn:nasa:pds:hst_$prop_id$:$info.collection_name$:$ipppssoot$_$info.suffix$::$version_id[0]$.0
+      </lidvid_reference>
       <reference_type>data_to_$"thumb" if "thumb" in info.suffix else "browse"$</reference_type>
     $IF("thumb" in info.suffix)
       <comment>Thumbnail browse product</comment>
@@ -316,7 +325,9 @@ $FOR(ref=reference_basenames)
 
   $ONCE(ref_dict=by_basename[ref])
     <Internal_Reference>
-      <lidvid_reference>urn:nasa:pds:hst_$prop_id$:$ref_dict["collection_name"]$:$ref_dict["ipppssoot"]$$ref_dict["lid_suffix"]$::$ref_dict["version_id"][0]$.$ref_dict["version_id"][1]$</lidvid_reference>
+      <lidvid_reference>
+        $ref_dict["product_lidvid"]$
+      </lidvid_reference>
       <reference_type>data_to_$ref_dict["processing_level"].lower()$_product</reference_type>
       <comment>
         $WRAP(8, 90, ref_dict["basename"] + ": " + ref_dict["product_title"])$


### PR DESCRIPTION
These are two minor changes, but should fix #95.

I think NaNs are properly understood to be "not applicable" rather than "invalid". We mainly see them at the periphery of reprojected images. However, it would be worthwhile to do a thorough review how NaNs are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Record which HDU extensions contain NaNs; added utility to extract time range from binary-table FITS.

- **Refactor**
  - Removed user-configurable NaN replacement and CLI flag; NaN-rewrite is no longer performed.
  - Labels now use centralized product identifiers (product_lid/product_lidvid) for references.
  - Browse-product suffix handling and related public interfaces simplified.

- **Documentation**
  - Removed NaN-replacement notes from generated labels; Special_Constants now mark NaN as “not applicable”.

- **Bug Fixes**
  - Improved FITS open/error logging (includes file path and continues); MTFLAG missing now warns instead of error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->