### PR TITLE
Fixes #108 and #110

### DIFF
--- a/HST/pipeline/pipeline_run.py
+++ b/HST/pipeline/pipeline_run.py
@@ -52,6 +52,9 @@ parser.add_argument('--max-allowed-time', '--max-time',
 parser.add_argument('--get-ids', '-g', action='store_true',
     help='Fetch ids from MAST to update the id list before running pipeline.')
 
+parser.add_argument('--nocleanup', action='store_true',
+    help="Don't delete the MAST download files.")
+
 # Default list of program ids
 ids_li = ['15648', '13667', '10161', '11113', '08152', '15142', '11650', '04600',
           '10423', '15929', '09354', '11573', '10719', '08699', '07430', '07583',
@@ -194,8 +197,10 @@ proposal_ids = args.proposal_ids if args.proposal_ids else ids_li
 
 run_pipeline(proposal_ids, logger)
 # Clean up the staging directories
-for id in proposal_ids:
-    clean_up_staging_dir(id, logger)
+if not args.nocleanup:
+    for id_ in proposal_ids:
+        clean_up_staging_dir(id_, logger)
+
 logger.close()
 
 ##########################################################################################

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -121,8 +121,8 @@ def label_hst_fits_filepaths(filepaths, root='', *,
             min_filepath = min(filepaths)
             max_filepath = max(filepaths)
         except ValueError as e:
-            logger.error(str(e) + ','.join(filepaths))
-            raise e
+            logger.exception(e)
+            raise
 
         for k, chars in enumerate(zip(min_filepath, max_filepath)):
             if chars[0] != chars[1]:
@@ -138,15 +138,13 @@ def label_hst_fits_filepaths(filepaths, root='', *,
         logger.info('Root of file paths: ' + root)
         logger.replace_root(root)
 
-    PdsTemplate.set_logger(logger)
-
     # Make sure the retrieval date, if any, is valid
     if retrieval_date:
         try:
             _ = datetime.date.fromisoformat(retrieval_date)
-        except ValueError:
-            logger.exception(ValueError)
-            sys.exit(1)
+        except ValueError as e:
+            logger.exception(e)
+            raise
 
     # Create a mapping from basename to old filepath
     old_fullpath_vs_basename = {os.path.basename(f):os.path.join(old_root, f)
@@ -185,7 +183,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
 
         # If this suffix is not accepted, skip it
         if suffix not in accepted_suffixes:
-            logger.warn(f'Suffix {suffix} rejected', filepath)
+            logger.info(f'Suffix {suffix} rejected', filepath)
             continue
 
         ##################################################################################
@@ -236,7 +234,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
             new_path = fullpath + '-duplicate'
             os.rename(fullpath, new_path)
             if content1 == content2:
-                logger.warn('Duplicated basename, renamed', new_path)
+                logger.info('Duplicated basename, renamed', new_path)
             else:
                 logger.error('Same basename, different content', new_path)
             continue
@@ -411,8 +409,8 @@ def label_hst_fits_filepaths(filepaths, root='', *,
 
         # Log an error if something happened that we don't understand
         if len(standard_tails) == 0:
-            logger.warn('No standard transmission characters found for ' +
-                        f'"{ipppssoo}": {nonstandard_tails}')
+            logger.error('No standard transmission characters found for ' +
+                         f'"{ipppssoo}": {nonstandard_tails}')
         elif len(standard_tails) > 1:
             logger.warn('Multiple standard transmission characters found for ' +
                         f'"{ipppssoo}": {standard_tails}')
@@ -500,7 +498,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
         if matches_found > 0:
             solo_ipppssoots.append(ipppssoot)
         if matches_found > 1:
-            logger.warn('File used by multiple IPPPSSOOTs', ipppssoot + '_asn.fits')
+            logger.info('File used by multiple IPPPSSOOTs', ipppssoot + '_asn.fits')
 
     for ipppssoot in solo_ipppssoots:
         del info_by_ipppssoot[ipppssoot]
@@ -574,7 +572,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
         if ipppssoot_dict['parent']:
             continue
         if not ipppssoot_dict['timetags']:
-            logger.warn(f'Missing trl timetags for {ipppssoot}')
+            logger.info(f'Missing trl timetags for {ipppssoot}')
 
     ######################################################################################
     # Identify the SPT/SHM/SHF file for each IPPPSSOOT.

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -630,6 +630,9 @@ def label_hst_fits_filepaths(filepaths, root='', *,
     ######################################################################################
 
     def find_suffix_dicts(ipppssoot_dict, suffixes):
+        """Return a list of reference IPPPSSOOT dicts for the given suffixes. These could
+        be from an associate.
+        """
         suffix_dicts = []
         for suffix in suffixes:
             if suffix in ipppssoot_dict['all_suffixes']:
@@ -639,8 +642,10 @@ def label_hst_fits_filepaths(filepaths, root='', *,
                     suffix_dicts.append(info_by_ipppssoot[associate][suffix])
         return suffix_dicts
 
+    # suffix_options is a list of sets of suffix strings. The first is for the IPPPSSOOT;
+    # the second is for the parent if this IPPPSSOOT has a parent. We only use a parent
+    # as a reference if there are no reference suffixes found for the IPPPSSOOT itself.
     for ipppssoot, ipppssoot_dict in info_by_ipppssoot.items():
-
         ipppssoot_dict['shared'] = len(ipppssoot_dict['parents']) > 1
         if ipppssoot_dict['parent']:
             parent = ipppssoot_dict['parent']
@@ -651,32 +656,29 @@ def label_hst_fits_filepaths(filepaths, root='', *,
             ipppssoot_dicts = [ipppssoot_dict]
             suffix_options = [ipppssoot_dict['merged_suffixes']]
 
-        # Check the REF_SUFFIXES list
-        tag = 'Reference'
-        for k, suffix_option in enumerate(suffix_options):
-            reference_suffixes = list(suffix_info.REF_SUFFIXES & suffix_option)
-            reference_dicts = find_suffix_dicts(ipppssoot_dicts[k], reference_suffixes)
-            if reference_suffixes:
-                break
-
-        # If that fails, check the ALT_REF_SUFFIXES list
-        if not reference_suffixes:
-            tag = 'Alternative reference'
+        # Search for a reference suffix among the available suffixes.
+        # There are three levels of suffix precedence defined in `suffix_info`; lower
+        # precedence suffixes are only used if all higher-precedence suffixes are absent.
+        # `tag` is one of "Reference", "Alternative Reference", or "Second Alt Reference".
+        for tag, suffixes in zip(suffix_info.REF_TAGS, suffix_info.REF_SUFFIXES):
             for k, suffix_option in enumerate(suffix_options):
-                reference_suffixes = list(suffix_info.ALT_REF_SUFFIXES & suffix_option)
+                reference_suffixes = list(suffixes & suffix_option)
                 reference_dicts = find_suffix_dicts(ipppssoot_dicts[k],
                                                     reference_suffixes)
                 if reference_suffixes:
                     break
+            if reference_suffixes:
+                break
 
         ipppssoot_dict['reference_suffixes'] = set(reference_suffixes)
         ipppssoot_dict['reference_dicts'] = reference_dicts
 
+        # Log the reference found
         count = len(reference_dicts)
-        if count > 1:
+        if count > 1:       # If there are multiple suitable references, just pick one
             for k, reference_dict in enumerate(reference_dicts):
                 logger.info(f'Multiple {tag.lower()} files found for {ipppssoot} ' +
-                             f'({k+1}/{count})', reference_dict['fullpath'])
+                            f'({k+1}/{count})', reference_dict['fullpath'])
             reference_suffix = reference_suffixes[0]
             reference_dict = reference_dicts[0]
         elif count == 1:
@@ -684,7 +686,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
                         reference_dicts[0]['fullpath'])
             reference_suffix = reference_suffixes[0]
             reference_dict = reference_dicts[0]
-        else:
+        else:               # In the absence of a reference file, we're stuck.
             logger.critical('No reference file for ' + ipppssoot)
             raise ValueError('No reference file for ' + ipppssoot)
 
@@ -1032,7 +1034,7 @@ def get_filepaths(directories, root='', match_pattern='', extension='.fits'):
     """Generate a list of file paths for processing.
 
     Input:
-        directories     directory path of a list of directory paths.
+        directories     directory path or a list of directory paths.
         root            optional path to prepend to each directory path.
         match_pattern   optional fnmatch pattern to use to filter the returned list.
     """

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -663,14 +663,15 @@ def label_hst_fits_filepaths(filepaths, root='', *,
         for tag, suffixes in zip(suffix_info.REF_TAGS, suffix_info.REF_SUFFIXES):
             for k, suffix_option in enumerate(suffix_options):
                 reference_suffixes = list(suffixes & suffix_option)
-                reference_dicts = find_suffix_dicts(ipppssoot_dicts[k],
-                                                    reference_suffixes)
                 if reference_suffixes:
+                    reference_suffixes.sort()       # make order deterministic
+                    reference_dicts = find_suffix_dicts(ipppssoot_dicts[k],
+                                                        reference_suffixes)
                     break
             if reference_suffixes:
                 break
 
-        ipppssoot_dict['reference_suffixes'] = set(reference_suffixes)
+        ipppssoot_dict['reference_suffixes'] = reference_suffixes
         ipppssoot_dict['reference_dicts'] = reference_dicts
 
         # Log the reference found

--- a/HST/product_labels/__init__.py
+++ b/HST/product_labels/__init__.py
@@ -6,7 +6,6 @@ import datetime
 import fnmatch
 import os
 import pathlib
-import shutil
 import sys
 from collections import defaultdict
 
@@ -660,6 +659,7 @@ def label_hst_fits_filepaths(filepaths, root='', *,
         # There are three levels of suffix precedence defined in `suffix_info`; lower
         # precedence suffixes are only used if all higher-precedence suffixes are absent.
         # `tag` is one of "Reference", "Alternative Reference", or "Second Alt Reference".
+        reference_suffixes = []
         for tag, suffixes in zip(suffix_info.REF_TAGS, suffix_info.REF_SUFFIXES):
             for k, suffix_option in enumerate(suffix_options):
                 reference_suffixes = list(suffixes & suffix_option)
@@ -671,28 +671,27 @@ def label_hst_fits_filepaths(filepaths, root='', *,
             if reference_suffixes:
                 break
 
-        ipppssoot_dict['reference_suffixes'] = reference_suffixes
-        ipppssoot_dict['reference_dicts'] = reference_dicts
-
-        # Log the reference found
-        count = len(reference_dicts)
-        if count > 1:       # If there are multiple suitable references, just pick one
-            for k, reference_dict in enumerate(reference_dicts):
-                logger.info(f'Multiple {tag.lower()} files found for {ipppssoot} ' +
-                            f'({k+1}/{count})', reference_dict['fullpath'])
-            reference_suffix = reference_suffixes[0]
-            reference_dict = reference_dicts[0]
-        elif count == 1:
-            logger.info(f'{tag} file found for ' + ipppssoot,
-                        reference_dicts[0]['fullpath'])
-            reference_suffix = reference_suffixes[0]
-            reference_dict = reference_dicts[0]
-        else:               # In the absence of a reference file, we're stuck.
+        # In the absence of a reference file, we're stuck
+        if not reference_suffixes:
             logger.critical('No reference file for ' + ipppssoot)
             raise ValueError('No reference file for ' + ipppssoot)
 
-        ipppssoot_dict['reference_suffix'] = reference_suffix
-        ipppssoot_dict['reference_dict'] = reference_dict
+        # Log the reference found
+        count = len(reference_dicts)
+        if count > 1:
+            for k, reference_dict in enumerate(reference_dicts):
+                logger.info(f'Multiple {tag.lower()} files found for {ipppssoot} ' +
+                            f'({k+1}/{count})', reference_dict['fullpath'])
+        else:
+            logger.info(f'{tag} file found for ' + ipppssoot,
+                        reference_dicts[0]['fullpath'])
+
+        ipppssoot_dict['reference_suffixes'] = reference_suffixes
+        ipppssoot_dict['reference_dicts'] = reference_dicts
+
+        # If there are multiple suitable references, just pick one
+        ipppssoot_dict['reference_suffix'] = reference_suffixes[0]
+        ipppssoot_dict['reference_dict'] = reference_dicts[0]
 
     ######################################################################################
     # Gather the metadata for each IPPPSSOOT:

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -388,7 +388,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
                         detector_ids = [ref_hdulist[0].header['SEGMENT']]
                         if detector_ids == ['BOTH']:
                             detector_ids = ['FUVA', 'FUVB']
-                        dectector_ids = [ref_hdulist[0].header['SEGMENT']]
+                        detector_ids = [ref_hdulist[0].header['SEGMENT']]
                     else:
                         logger.error('COS/FUV table does not have a column "SEGMENT"',
                                      filepath)

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -533,7 +533,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG', 'INDETERMINATE')
+        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG')
 
     ##############################
     # filter_name
@@ -643,8 +643,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['fine_guidance_sensor_lock_type'] = get_or_log(merged, 'FGSLOCK',
-                                                                      'UNKNOWN')
+        hst_dictionary['fine_guidance_sensor_lock_type'] = get_or_log(merged, 'FGSLOCK')
 
     ##############################
     # gain_setting

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -169,13 +169,16 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     associated with each EXTVER in a label.
     """
 
-    def get_or_log(header, key, alt='UNK'):
+    def get_or_log(header, key, alt='UNK', warn=False):
         """Internal function to look up in given FITS header; log error on failure.
         """
         try:
             return header[key]
         except KeyError:
-            logger.error('Missing FITS keyword ' + key, filepath)
+            if warn:
+                logger.warn(f'Missing FITS keyword {key} repaired', filepath)
+            else:
+                logger.error(f'Missing FITS keyword {key}', filepath)
             return alt
 
     logger = logger or pdslogger.NullLogger()
@@ -240,6 +243,13 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
         'targeted_detector_ids'         : ['UNK'],
         'visit_id'                      : 'UNK',
     }
+
+    ##############################
+    # hst_proposal_id
+    ##############################
+
+    hst_proposal_id = get_or_log(merged, 'PROPOSID')
+    hst_dictionary['hst_proposal_id'] = hst_proposal_id
 
     ##############################
     # instrument_id
@@ -523,7 +533,8 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        exposure_duration = get_or_log(merged, 'EXPTIME', 0.)
+        warn_if_missing = hst_proposal_id in {5167, 5837, 6025, 6029}
+        exposure_duration = get_or_log(merged, 'EXPTIME', 0., warn=warn_if_missing)
         exposure_duration = round(exposure_duration, 3)     # strip extraneous precision
         hst_dictionary['exposure_duration'] = exposure_duration
 
@@ -532,7 +543,9 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG')
+        warn_if_missing = hst_proposal_id in {5167, 5837, 6025, 6029}
+        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG',
+                                                     warn=warn_if_missing)
 
     ##############################
     # filter_name
@@ -642,7 +655,9 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['fine_guidance_sensor_lock_type'] = get_or_log(merged, 'FGSLOCK')
+        warn_if_missing = hst_proposal_id in {5167, 5837, 6025, 6029}
+        lock_type = get_or_log(merged, 'FGSLOCK', warn=warn_if_missing)
+        hst_dictionary['fine_guidance_sensor_lock_type'] = lock_type
 
     ##############################
     # gain_setting
@@ -690,12 +705,6 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
         hst_pi_name = _join_hst_pi_name(pr_inv_l, pr_inv_f, pr_inv_m)
 
     hst_dictionary['hst_pi_name'] = hst_pi_name
-
-    ##############################
-    # hst_proposal_id
-    ##############################
-
-    hst_dictionary['hst_proposal_id'] = get_or_log(merged, 'PROPOSID')
 
     ##############################
     # hst_quality_comment

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -382,10 +382,17 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
             elif isinstance(ref_hdulist[1].data, pyfits.fitsrec.FITS_rec):
                 try:
                     detector_ids = list(ref_hdulist[1].data['SEGMENT'])
+                    detector_ids.sort()
                 except KeyError:
-                    logger.error('COS/FUV table does not have a column "SEGMENT"',
-                                 filepath)
-                    detector_ids = ['UNK']
+                    if 'SEGMENT' in ref_hdulist[0].header:
+                        detector_ids = [ref_hdulist[0].header['SEGMENT']]
+                        if detector_ids == ['BOTH']:
+                            detector_ids = ['FUVA', 'FUVB']
+                        dectector_ids = [ref_hdulist[0].header['SEGMENT']]
+                    else:
+                        logger.error('COS/FUV table does not have a column "SEGMENT"',
+                                     filepath)
+                        detector_ids = ['UNK']
 
             else:
                 logger.error('COS/FUV file does not contain "_a" or "_b"', filepath)
@@ -526,7 +533,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG', 0.)
+        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG')
 
     ##############################
     # filter_name
@@ -574,7 +581,10 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
 
         elif instrument_id == 'GHRS':
             if scidata:
-                filter_name = header0['GRATING']
+                if 'GRATING' in header0:
+                    filter_name = header0['GRATING']
+                else:
+                    filter_name = get_or_log(header0, 'SS_GRAT')
             else:
                 filter_name = spt_header['SPEC_1']
 

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -388,7 +388,6 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
                         detector_ids = [ref_hdulist[0].header['SEGMENT']]
                         if detector_ids == ['BOTH']:
                             detector_ids = ['FUVA', 'FUVB']
-                        detector_ids = [ref_hdulist[0].header['SEGMENT']]
                     else:
                         logger.error('COS/FUV table does not have a column "SEGMENT"',
                                      filepath)

--- a/HST/product_labels/hst_dictionary_support.py
+++ b/HST/product_labels/hst_dictionary_support.py
@@ -533,7 +533,7 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG')
+        hst_dictionary['exposure_type'] = get_or_log(merged, 'EXPFLAG', 'INDETERMINATE')
 
     ##############################
     # filter_name
@@ -643,7 +643,8 @@ def fill_hst_dictionary(ref_hdulist, spt_hdulist, filepath='', logger=None):
     ##############################
 
     if scidata:
-        hst_dictionary['fine_guidance_sensor_lock_type'] = get_or_log(merged, 'FGSLOCK')
+        hst_dictionary['fine_guidance_sensor_lock_type'] = get_or_log(merged, 'FGSLOCK',
+                                                                      'UNKNOWN')
 
     ##############################
     # gain_setting

--- a/HST/product_labels/suffix_info.py
+++ b/HST/product_labels/suffix_info.py
@@ -178,12 +178,17 @@ ALL_SUFFIXES = {
 # This might be a useful resource: https://archive.stsci.edu/hst/manifestkeywords.html
 ##########################################################################################
 
-REF_SUFFIXES = {'raw', 'd0m', 'd0f',
-                'a1f', 'a2f', 'a3f',                    # FGS
-                'rawtag',   'rawtag_a',   'rawtag_b',   # COS...
+# The reference suffix is the one file with a given IPPPSSOOT that defines the instrument
+# parameters and time coordinates. There are three sets of options in decreasing order of
+# preference.
+REF_SUFFIXES = [{'raw', 'd0m', 'd0f',
+                'a1f', 'a2f', 'a3f',                            # FGS
+                'rawtag',   'rawtag_a',   'rawtag_b',           # COS...
                 'rawaccum', 'rawaccum_a', 'rawaccum_b',
-                'rawacq',   'rawacq_a',   'rawacq_b'}
-ALT_REF_SUFFIXES = {'mos', 'drz', 'x1dsum', 'fltsum', 'd1f'}    # d1f needed for GHRS
+                'rawacq',   'rawacq_a',   'rawacq_b'},
+                {'mos', 'drz', 'x1dsum', 'fltsum', 'd1f'},      # d1f needed for GHRS
+                {'shf'}]     # shf needed for some GHRS that lack d1f
+REF_TAGS = ['Reference', 'Alternative reference', 'Second alternative reference']
 SPT_SUFFIXES = {'spt', 'shm', 'shf', 'dmf'}
 
 # These are used when we only want to download files for target identification testing

--- a/HST/templates/PRODUCT_LABEL.xml
+++ b/HST/templates/PRODUCT_LABEL.xml
@@ -243,12 +243,12 @@ $FOR(detector,k,count=hst_dictionary["targeted_detector_ids"])
 $END_FOR
         </hst:Pointing_Parameters>
         <hst:Tracking_Parameters>
-          <hst:fine_guidance_sensor_lock_type>$hst_dictionary["fine_guidance_sensor_lock_type"]$</hst:fine_guidance_sensor_lock_type>
+          <hst:fine_guidance_sensor_lock_type>$REPLACE_UNK(hst_dictionary["fine_guidance_sensor_lock_type"], 'UNKNOWN')$</hst:fine_guidance_sensor_lock_type>
           <hst:gyroscope_mode>$hst_dictionary["gyroscope_mode"]$</hst:gyroscope_mode>
         </hst:Tracking_Parameters>
         <hst:Exposure_Parameters>
           <hst:exposure_duration unit="s">$hst_dictionary["exposure_duration"]$</hst:exposure_duration>
-          <hst:exposure_type>$hst_dictionary["exposure_type"]$</hst:exposure_type>
+          <hst:exposure_type>$REPLACE_UNK(hst_dictionary["exposure_type"], 'INDETERMINATE')$</hst:exposure_type>
         </hst:Exposure_Parameters>
         <hst:Wavelength_Filter_Grating_Parameters>
           <hst:filter_name>$hst_dictionary["filter_name"]$</hst:filter_name>


### PR DESCRIPTION
Fixes #108: The "SEGMENT" keyword was at a different place in the labels.

Fixes #110: These products actual show up as errors in the MAST API too. They seem to be observations with no data, just ancillary information, so they would be of limited value for actual science. Nevertheless, we don't want them to break the pipeline. I fixed things so that most of the information gets filled into the label. However, there are no values for `fine_guidance_sensor_lock_type`, `exposure_duration`, or `exposure_type`. I am now using these values in the label:
```
<hst:fine_guidance_sensor_lock_type>UNKNOWN</hst:fine_guidance_sensor_lock_type>
<hst:exposure_duration unit="s">0.</hst:exposure_duration>
<hst:exposure_type>INDETERMINATE</hst:exposure_type>
```
The keywords are consistent with what the DD defines as quasi-standard values. The exposure duration of zero is a reasonable clue that there is no data. If anyone has a better idea, such as to specify a `nilReason`, we can update the DD and then change the template accordingly. We would not have to change the source code, just the template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional --nocleanup flag to preserve downloaded files after processing.

* **Improvements**
  * Multi-tier reference-file selection with clear precedence and deterministic ordering.
  * Better handling of detector/segment identification and exposure/filter resolution.
  * Product labels now normalize unknown values for consistency.
  * Logging and error handling tightened to surface issues without abruptly exiting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->